### PR TITLE
Added new installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,23 @@ Note: for this initial release, only *S3* provider is supported.
 
 # Installation
 
-Declare the plugin dependency in the `build.gradle`, as shown here:
+Build script snippet for use in all Gradle versions:
+```groovy
+buildscript {
+  repositories {
+    maven {
+      url "https://plugins.gradle.org/m2/"
+    }
+  }
+  dependencies {
+    classpath "gradle.plugin.agorapulse.plugins:asset-pipeline-cdn:0.1.2"
+  }
+}
+
+apply plugin: "agorapulse.plugins.asset-pipeline-cdn"
+```
+
+Build script snippet for new, incubating, plugin mechanism introduced in Gradle 2.1:
 
 ```groovy
 plugins {


### PR DESCRIPTION
Added installation instructions for different gradle versions, taken from https://plugins.gradle.org/plugin/agorapulse.plugins.asset-pipeline-cdn
